### PR TITLE
Izzy feat auth

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,18 +14,11 @@
   text-decoration: none;
 }
 
-.logo-wrapper {
-  cursor: pointer;
-}
+.logo-wrapper { cursor: pointer; }
 
-.navbar {
-  justify-content: space-between;
-}
+.navbar { justify-content: space-between; }
 
-.navbar > a {
-  text-decoration: none;
-  color: #ffffff;
-}
+.navbar > a { text-decoration: none; }
 
 .nav-right {
   display: flex;
@@ -38,17 +31,14 @@
   margin-left: 1.25rem;
 }
 
-header {
-  padding: 1.4rem;
-  background-color: #242424;
-}
+header { padding: .8rem; }
 
 header div {
   display: flex;
   justify-content: center;
 }
 header div img {
-  width: 60px;
+  width: 50px;
   height: auto;
 }
 
@@ -64,17 +54,39 @@ header nav ul {
   list-style: none;
 }
 
-header nav ul li {
-  margin-left: 1.25rem;
-}
+header nav ul li { margin-left: 1.25rem; }
 
 header nav ul li a {
   font-weight: 900;
-  color: #ffffff;
   text-decoration: none;
   transition: color 150ms ease-in;
 }
 
-header nav ul li a:hover {
-  color: #03d1ff;
+header nav ul li a:hover { color: #03d1ff; }
+
+.light {
+  background-color: white;
+  color: black;
+  transition: ease-in .5s;
 }
+.light header {
+  background-color: #cfcfcf; /* lighter shade for light mode */
+  color: black;
+  transition: ease-in .5s;
+}
+.light header nav ul li a { color: black; }
+.light .navbar > a { color: black; }
+
+.dark {
+  background-color: #121212;
+  color: white;
+  transition: ease-in .8s;
+}
+.dark header nav ul li a { color: white; }
+.dark header {
+  background-color: #1a1a1a; /* darker shade for dark mode */
+  color: white;
+  transition: ease-in .8s;
+}
+.dark header nav ul li a { color: white; }
+.navbar > a { color: white; }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,24 @@
 import './App.css';
 import Header from './components/Header';
+import { useState } from 'react';
 
 function App() {
+
+  //currently setting the variable to false, as it is not in Light Mode
+  const [isLightMode, setIsLightMode] = useState(false);
+
+  const toggleTheme = () => {
+    setIsLightMode(prev => !prev);
+  }
+
+
   return (
-    <>
-      <Header />
+    <div className={isLightMode ? 'light' : 'dark'}>
+      <Header toggleTheme={toggleTheme} />
       <div className="container">
         <h2>Main Content</h2>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,8 @@
 import { CgDarkMode } from 'react-icons/cg';
+import React from 'react';
 
-const Header = () => {
+const Header = ({toggleTheme}) => {
+
   return (
     <header>
       <div className="container navbar">
@@ -27,7 +29,7 @@ const Header = () => {
               </li>
             </ul>
           </nav>
-          <CgDarkMode className="theme-toggle" />
+          <CgDarkMode className="theme-toggle" onClick={toggleTheme} />
         </div>
       </div>
     </header>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,4 @@
 import { CgDarkMode } from 'react-icons/cg';
-import React from 'react';
 
 const Header = ({toggleTheme}) => {
 


### PR DESCRIPTION
dark mode and light functionality enabled

modification:
- a App.jsx tag structure,
- provided single argument to Header component
- added new css styling
- moved the colours to the new css due to overriding issues
- removed unneccessary and irrelevant import (dunno why why it was there to begin with)
-  provided enough shading to tell difference between header and main

DOING NOW:
- flip the colour as lighter tone should take precedent for main section
- make the main component and give it 100 vh viewport to stimulate full body view